### PR TITLE
Support multiple parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@
   * [Usage](#usage)
      * [Parameters](#parameters)
      * [Examples](#examples)
-        * [Singular paramter value](#singular-parameter-value)
-        * [List of parameter values](#list-of-parameter-values)
+        * [Get single parameter value](#get-single-parameter-value)
+        * [Get multiple parameter values](#get-multiple-parameter-values)
         * [Custom prefix](#custom-prefix)
         * [Simple JSON parameter values](#simple-json-parameter-values)
         * [Complex JSON values](#complex-json-values)
@@ -37,14 +37,14 @@ Action expects 3 secrets to be set in GitHub's repository:
 
 Parameter name | Type | Required | Default Value | Description
 --- | --- | --- | --- | ---
-`ssm_parameter_list` | string | true | | AWS Systems Manager parameter name (path) or comma seperated list of paths
+`ssm_parameter_list` | string | true | | AWS Systems Manager parameter name (path) or comma separated list of paths
 `prefix` | string | false | AWS_SSM_ | Custom environmental variables prefix
 `simple_json` | boolean | true | false | Parse parameter values as one-level JSON object and convert keys to environmental variables (see example below).
 `jq_params` | string | true | | Custom space-separated [`jq` filters](https://stedolan.github.io/jq/) (see example below).
 
 ### Examples
 
-#### Singular parameter value
+#### Get single parameter value
 
 Parse simple string value stored in AWS SSM `my_parameter_name` parameter:
 ```yaml
@@ -69,9 +69,9 @@ jobs:
 
 Example above will set environmental variable `AWS_SSM_MY_PARAMETER_NAME` with value from the AWS SSM parameter itself.
 
-#### List of parameter values
+#### Get multiple parameter values
 
-Itterate list of simple string value stored in AWS SSM by providing list of SSM paths:
+Use comma separated list of strings to fetch multiple parameter values at once:
 ```yaml
 name: Parse SSM parameter
 
@@ -94,7 +94,7 @@ jobs:
            my_second_parameter
 ```
 
-Example above will set environmental variable `AWS_SSM_MY_FIRST_PARAMTER` and `AWS_SSM_MY_SECOND_PARAMTER` with corresponding values from AWS SSM.
+Example above will set environmental variable `AWS_SSM_MY_FIRST_PARAMETER` and `AWS_SSM_MY_SECOND_PARAMETER` with corresponding values from AWS SSM.
 
 #### Custom prefix
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@
   * [Usage](#usage)
      * [Parameters](#parameters)
      * [Examples](#examples)
-        * [String values](#string-values)
+        * [Singular paramter value](#singular-parameter-value)
+        * [List of parameter values](#list-of-parameter-values)
         * [Custom prefix](#custom-prefix)
         * [Simple JSON parameter values](#simple-json-parameter-values)
         * [Complex JSON values](#complex-json-values)
@@ -36,14 +37,14 @@ Action expects 3 secrets to be set in GitHub's repository:
 
 Parameter name | Type | Required | Default Value | Description
 --- | --- | --- | --- | ---
-`ssm_parameter` | string | true | | AWS Systems Manager parameter name (path)
+`ssm_parameter_list` | string | true | | AWS Systems Manager parameter name (path) or comma seperated list of paths
 `prefix` | string | false | AWS_SSM_ | Custom environmental variables prefix
 `simple_json` | boolean | true | false | Parse parameter values as one-level JSON object and convert keys to environmental variables (see example below).
 `jq_params` | string | true | | Custom space-separated [`jq` filters](https://stedolan.github.io/jq/) (see example below).
 
 ### Examples
 
-#### String values
+#### Singular parameter value
 
 Parse simple string value stored in AWS SSM `my_parameter_name` parameter:
 ```yaml
@@ -63,10 +64,37 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         with:
-          ssm_parameter: 'my_parameter_name'
+          ssm_parameter_list: 'my_parameter_name'
 ```
 
 Example above will set environmental variable `AWS_SSM_MY_PARAMETER_NAME` with value from the AWS SSM parameter itself.
+
+#### List of parameter values
+
+Itterate list of simple string value stored in AWS SSM by providing list of SSM paths:
+```yaml
+name: Parse SSM parameter
+
+on:
+  push
+
+jobs:
+  aws-ssm-to-env:
+    runs-on: ubuntu-latest
+    steps:
+      - name: aws-ssm-to-env
+        uses: bomb-on/aws-ssm-to-env@master
+        env:
+          AWS_REGION: ${{ secrets.AWS_REGION }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        with:
+          ssm_parameter_list: |
+           my_first_parameter,
+           my_second_parameter
+```
+
+Example above will set environmental variable `AWS_SSM_MY_FIRST_PARAMTER` and `AWS_SSM_MY_SECOND_PARAMTER` with corresponding values from AWS SSM.
 
 #### Custom prefix
 
@@ -89,7 +117,7 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         with:
-          ssm_parameter: 'my_parameter_name'
+          ssm_parameter_list: 'my_parameter_name'
           prefix: FOO_
 ```
 
@@ -115,7 +143,7 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         with:
-          ssm_parameter: 'my_json_parameter'
+          ssm_parameter_list: 'my_json_parameter'
           simple_json: true
 ```
 
@@ -149,7 +177,7 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         with:
-          ssm_parameter: 'my_json_parameter'
+          ssm_parameter_list: 'my_json_parameter'
           jq_filter: '.db[]|select(.default).host .db[]|select(.default).port'
           prefix: DB_
 ```

--- a/action.yml
+++ b/action.yml
@@ -2,9 +2,12 @@ name: 'Parse AWS SSM Parameter values'
 description: 'Parse AWS Systems Manager parameters to environment variables'
 author: 'bomb-on'
 inputs:
+  ssm_parameter_list:
+    description: 'AWS Systems Manager parameter name (path) list.'
+    required: false
   ssm_parameter:
     description: 'AWS Systems Manager parameter name (path).'
-    required: true
+    required: false
   prefix:
     description: 'Custom environmental variables prefix.'
     required: false

--- a/action.yml
+++ b/action.yml
@@ -4,10 +4,7 @@ author: 'bomb-on'
 inputs:
   ssm_parameter_list:
     description: 'AWS Systems Manager parameter name (path) list.'
-    required: false
-  ssm_parameter:
-    description: 'AWS Systems Manager parameter name (path).'
-    required: false
+    required: true
   prefix:
     description: 'Custom environmental variables prefix.'
     required: false

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -46,7 +46,7 @@ get_ssm_param() {
   fi
 }
 
-for paramter in $(echo $parameter_name_list | sed "s/,/ /g"); do
+for parameter in $(echo $parameter_name_list | sed "s/,/ /g"); do
 get_ssm_param "$parameter"
 done
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -30,19 +30,19 @@ get_ssm_param() {
     if [ -n "$simple_json" ] && [ "$simple_json" == "true" ]; then
       for p in $(echo "$ssm_param_value" | jq -r --arg v "$prefix" 'to_entries|map("\(.key)=\(.value|tostring)")|.[]' ); do
         IFS='=' read -r var_name var_value <<< "$p"
-        echo ::set-env name="$(format_var_name "$var_name")"::"$var_value"
+        echo "$(format_var_name "$var_name")=$var_value" >> $GITHUB_ENV
       done
     else
       IFS=' ' read -r -a params <<< "$jq_filter"
       for var_name in "${params[@]}"; do
         var_value=$(echo "$ssm_param_value" | jq -r -c "$var_name")
-        echo ::set-env name="$(format_var_name "$var_name")"::"$var_value"
+        echo "$(format_var_name "$var_name")=$var_value" >> $GITHUB_ENV
       done
     fi
   else
     var_name=$(echo "$ssm_param" | jq -r '.Parameter.Name' | awk -F/ '{print $NF}')
     var_value=$(echo "$ssm_param" | jq -r '.Parameter.Value')
-    echo ::set-env name="$(format_var_name "$var_name")"::"$var_value"
+    echo "$(format_var_name "$var_name")=$var_value" >> $GITHUB_ENV
   fi
 }
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,38 +7,47 @@ if [[ -z "$AWS_REGION" ]] || [[ -z "$AWS_ACCESS_KEY_ID" ]] || [[ -z "$AWS_SECRET
   exit 1
 fi
 
-if [[ -z "$INPUT_SSM_PARAMETER" ]]; then
-  echo "Set SSM parameter name (parameter_name) value."
+if [[ -z "$INPUT_SSM_PARAMETER_LIST" ]]; then
+  echo "Set SSM parameter name list (parameter_name_list) value(s)."
   exit 1
 fi
 
 region="$AWS_REGION"
-parameter_name="$INPUT_SSM_PARAMETER"
+parameter_name_list="$INPUT_SSM_PARAMETER_LIST"
 prefix="${INPUT_PREFIX:-AWS_SSM_}"
 jq_filter="$INPUT_JQ_FILTER"
 simple_json="$INPUT_SIMPLE_JSON"
-ssm_param=$(aws --region "$region" ssm get-parameter --name "$parameter_name")
 
 format_var_name () {
   echo "$1" | awk -v prefix="$prefix" -F. '{print prefix $NF}' | tr "[:lower:]" "[:upper:]"
 }
 
-if [ -n "$jq_filter" ] || [ -n "$simple_json" ]; then
-  ssm_param_value=$(echo "$ssm_param" | jq '.Parameter.Value | fromjson')
-  if [ -n "$simple_json" ] && [ "$simple_json" == "true" ]; then
-    for p in $(echo "$ssm_param_value" | jq -r --arg v "$prefix" 'to_entries|map("\(.key)=\(.value|tostring)")|.[]' ); do
-      IFS='=' read -r var_name var_value <<< "$p"
-      echo ::set-env name="$(format_var_name "$var_name")"::"$var_value"
-    done
+get_ssm_param() {
+  parameter_name="$1"
+  ssm_param=$(aws --region "$region" ssm get-parameter --name "$parameter_name")
+  if [ -n "$jq_filter" ] || [ -n "$simple_json" ]; then
+    ssm_param_value=$(echo "$ssm_param" | jq '.Parameter.Value | fromjson')
+    if [ -n "$simple_json" ] && [ "$simple_json" == "true" ]; then
+      for p in $(echo "$ssm_param_value" | jq -r --arg v "$prefix" 'to_entries|map("\(.key)=\(.value|tostring)")|.[]' ); do
+        IFS='=' read -r var_name var_value <<< "$p"
+        echo ::set-env name="$(format_var_name "$var_name")"::"$var_value"
+      done
+    else
+      IFS=' ' read -r -a params <<< "$jq_filter"
+      for var_name in "${params[@]}"; do
+        var_value=$(echo "$ssm_param_value" | jq -r -c "$var_name")
+        echo ::set-env name="$(format_var_name "$var_name")"::"$var_value"
+      done
+    fi
   else
-    IFS=' ' read -r -a params <<< "$jq_filter"
-    for var_name in "${params[@]}"; do
-      var_value=$(echo "$ssm_param_value" | jq -r -c "$var_name")
-      echo ::set-env name="$(format_var_name "$var_name")"::"$var_value"
-    done
+    var_name=$(echo "$ssm_param" | jq -r '.Parameter.Name' | awk -F/ '{print $NF}')
+    var_value=$(echo "$ssm_param" | jq -r '.Parameter.Value')
+    echo ::set-env name="$(format_var_name "$var_name")"::"$var_value"
   fi
-else
-  var_name=$(echo "$ssm_param" | jq -r '.Parameter.Name' | awk -F/ '{print $NF}')
-  var_value=$(echo "$ssm_param" | jq -r '.Parameter.Value')
-  echo ::set-env name="$(format_var_name "$var_name")"::"$var_value"
-fi
+}
+
+for paramter in $(echo $parameter_name_list | sed "s/,/ /g"); do
+get_ssm_param "$parameter"
+done
+
+

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -47,7 +47,7 @@ get_ssm_param() {
 }
 
 for parameter in $(echo $parameter_name_list | sed "s/,/ /g"); do
-get_ssm_param "$parameter"
+  get_ssm_param "$parameter"
 done
 
 


### PR DESCRIPTION
I found myself repeating calls to this action over and over like so:

```yaml
    - name: aws-ssm-to-env
      uses: bomb-on/aws-ssm-to-env@master
      with:
        ssm_parameter: 'PARAM_1'
        prefix: 'PREFIX_'

    - name: aws-ssm-to-env
      uses: bomb-on/aws-ssm-to-env@master
      with:
        ssm_parameter: 'PARAM_2'
        prefix: 'PREFIX_'

    - name: aws-ssm-to-env
      uses: bomb-on/aws-ssm-to-env@master
      with:
        ssm_parameter: 'PARAM_3'
        prefix: 'PREFIX_'
```

So I tweaked the bash script to accept either a singular string or a comma separated list of strings as inputs, the result being:

```yaml
    - name: aws-ssm-to-env
      uses: craigtsmith/aws-ssm-to-env@master
      with:
        ssm_parameter_list: | 
          PARAM_1, 
          PARAM_2, 
          PARAM_3
        prefix: 'PREFIX_'
```

Maybe somebody will find it useful :) 

Thanks for the action! Any changes you want me to make let me know.